### PR TITLE
Lesson 10: Implement Outbox Pattern in Friend Service

### DIFF
--- a/services/friend/Makefile
+++ b/services/friend/Makefile
@@ -1,9 +1,12 @@
 .PHONY: kube-deploy .build-image .kube-apply-configmap .kube-apply-namespace .kube-deploy-blue-green \
-		.kube-deploy-canary .kube-status .kube-logs .kube-service kube-clean port-forward generate swagger-generate
+		.kube-deploy-canary .kube-status .kube-logs .kube-service kube-clean port-forward generate swagger-generate \
+		gogenerate test test-coverage wire migrate-create migrate-up migrate-down migrate-force
 
 IMAGE_NAME := friend-service
 IMAGE_TAG := latest
 DOCKER_IMAGE := $(IMAGE_NAME):$(IMAGE_TAG)
+
+MIGRATIONS_FOLDER := migrations
 
 kube-deploy: .build-image .kube-deploy-blue-green
 
@@ -103,3 +106,16 @@ test-coverage:
 
 wire:
 	wire ./internal/di/wire.go
+
+# Migration commands
+migrate-create:
+	migrate create -ext sql -dir $(MIGRATIONS_FOLDER) -seq $(name)
+
+migrate-up:
+	migrate -path $(MIGRATIONS_FOLDER) -database $(DATABASE_URL) up
+
+migrate-down:
+	migrate -path $(MIGRATIONS_FOLDER) -database $(DATABASE_URL) down
+
+migrate-force:
+	migrate -path $(MIGRATIONS_FOLDER) -database $(DATABASE_URL) force $(version)

--- a/services/friend/internal/core/models/outbox.go
+++ b/services/friend/internal/core/models/outbox.go
@@ -1,0 +1,12 @@
+package models
+
+import "time"
+
+type OutboxEvent struct {
+	ID          int
+	EventType   string
+	Payload     interface{}
+	Status      string
+	CreatedAt   time.Time
+	ProcessedAt *time.Time
+}

--- a/services/friend/internal/core/ports/repository.go
+++ b/services/friend/internal/core/ports/repository.go
@@ -12,6 +12,13 @@ type FriendRepository interface {
 	RemoveFriend(ctx context.Context, userID, friendID string) error
 }
 
+type OutboxRepository interface {
+	Add(ctx context.Context, event models.OutboxEvent) error
+	GetPendingEvents(ctx context.Context, limit int) ([]models.OutboxEvent, error)
+	MarkAsProcessed(ctx context.Context, id int) error
+}
+
 type Repository interface {
 	Friend() FriendRepository
+	Outbox() OutboxRepository
 }

--- a/services/friend/internal/core/ports/service.go
+++ b/services/friend/internal/core/ports/service.go
@@ -1,0 +1,14 @@
+package ports
+
+import (
+	"context"
+)
+
+type OutboxProcessor interface {
+	Start(ctx context.Context)
+	Stop()
+}
+
+type Service interface {
+	OutboxProcessor() OutboxProcessor
+}

--- a/services/friend/internal/repository/outbox_repository.go
+++ b/services/friend/internal/repository/outbox_repository.go
@@ -1,0 +1,60 @@
+package repository
+
+import (
+	"context"
+	"encoding/json"
+	"time"
+
+	"github.com/popeskul/awesome-messanger/services/friend/internal/core/models"
+	"github.com/popeskul/awesome-messanger/services/friend/internal/core/ports"
+	platformPorts "github.com/popeskul/awesome-messanger/services/platform/database/postgres/ports"
+)
+
+type outboxRepository struct {
+	conn platformPorts.Connection
+}
+
+func NewOutboxRepository(conn platformPorts.Connection) ports.OutboxRepository {
+	return &outboxRepository{conn: conn}
+}
+
+func (r *outboxRepository) Add(ctx context.Context, event models.OutboxEvent) error {
+	query := `INSERT INTO outbox (event_type, payload, status) VALUES ($1, $2, $3)`
+	payload, err := json.Marshal(event.Payload)
+	if err != nil {
+		return err
+	}
+	_, err = r.conn.Exec(ctx, query, event.EventType, payload, "pending")
+	return err
+}
+
+func (r *outboxRepository) GetPendingEvents(ctx context.Context, limit int) ([]models.OutboxEvent, error) {
+	query := `SELECT id, event_type, payload, status, created_at FROM outbox WHERE status = 'pending' ORDER BY created_at LIMIT $1`
+	rows, err := r.conn.Query(ctx, query, limit)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var events []models.OutboxEvent
+	for rows.Next() {
+		var event models.OutboxEvent
+		var payload []byte
+		err := rows.Scan(&event.ID, &event.EventType, &payload, &event.Status, &event.CreatedAt)
+		if err != nil {
+			return nil, err
+		}
+		err = json.Unmarshal(payload, &event.Payload)
+		if err != nil {
+			return nil, err
+		}
+		events = append(events, event)
+	}
+	return events, nil
+}
+
+func (r *outboxRepository) MarkAsProcessed(ctx context.Context, id int) error {
+	query := `UPDATE outbox SET status = 'processed', processed_at = $1 WHERE id = $2`
+	_, err := r.conn.Exec(ctx, query, time.Now(), id)
+	return err
+}

--- a/services/friend/internal/repository/repository.go
+++ b/services/friend/internal/repository/repository.go
@@ -2,19 +2,25 @@ package repository
 
 import (
 	"github.com/popeskul/awesome-messanger/services/friend/internal/core/ports"
-	platformPorst "github.com/popeskul/awesome-messanger/services/platform/database/postgres/ports"
+	platformPorts "github.com/popeskul/awesome-messanger/services/platform/database/postgres/ports"
 )
 
 type repositories struct {
 	friendRepo ports.FriendRepository
+	outboxRepo ports.OutboxRepository
 }
 
-func NewRepositories(conn platformPorst.Connection) ports.Repository {
+func NewRepositories(conn platformPorts.Connection) ports.Repository {
 	return &repositories{
 		friendRepo: NewFriendRepository(conn),
+		outboxRepo: NewOutboxRepository(conn),
 	}
 }
 
 func (r *repositories) Friend() ports.FriendRepository {
 	return r.friendRepo
+}
+
+func (r *repositories) Outbox() ports.OutboxRepository {
+	return r.outboxRepo
 }

--- a/services/friend/internal/service/outbox_processor_service.go
+++ b/services/friend/internal/service/outbox_processor_service.go
@@ -1,0 +1,71 @@
+package service
+
+import (
+	"context"
+	"time"
+
+	"github.com/popeskul/awesome-messanger/services/friend/internal/core/ports"
+)
+
+var (
+	interval      = 5 * time.Second
+	processAtTime = 10
+)
+
+type OutboxProcessor struct {
+	repo   ports.Repository
+	logger ports.Logger
+}
+
+func NewOutboxProcessor(repo ports.Repository, logger ports.Logger) *OutboxProcessor {
+	return &OutboxProcessor{
+		repo:   repo,
+		logger: logger,
+	}
+}
+
+func (p *OutboxProcessor) Start(ctx context.Context) {
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			if err := p.processEvents(ctx); err != nil {
+				p.logger.Error("Error processing outbox events: %v", err)
+			}
+		}
+	}
+}
+
+func (p *OutboxProcessor) processEvents(ctx context.Context) error {
+	events, err := p.repo.Outbox().GetPendingEvents(ctx, processAtTime)
+	if err != nil {
+		return err
+	}
+
+	for _, event := range events {
+		// Here you would publish the event to your message broker
+		// For example:
+		// err := p.kafkaClient.Publish(event.EventType, event.Payload)
+		// if err != nil {
+		//     p.logger.Error("Failed to publish event: %v", err)
+		//     continue
+		// }
+
+		// For now, we'll just log the event
+		p.logger.Info("Processing event: %s", event.EventType)
+
+		if err := p.repo.Outbox().MarkAsProcessed(ctx, event.ID); err != nil {
+			p.logger.Error("Failed to mark event as processed: %v", err)
+		}
+	}
+
+	return nil
+}
+
+func (p *OutboxProcessor) Stop() {
+	p.logger.Info("Stopping outbox processor")
+}

--- a/services/friend/internal/service/service.go
+++ b/services/friend/internal/service/service.go
@@ -1,0 +1,17 @@
+package service
+
+import "github.com/popeskul/awesome-messanger/services/friend/internal/core/ports"
+
+type service struct {
+	processor ports.OutboxProcessor
+}
+
+func NewService(processor ports.OutboxProcessor) ports.Service {
+	return &service{
+		processor: processor,
+	}
+}
+
+func (s *service) OutboxProcessor() ports.OutboxProcessor {
+	return s.processor
+}

--- a/services/friend/migrations/000001_create_outbox_table.down.sql
+++ b/services/friend/migrations/000001_create_outbox_table.down.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS outbox;

--- a/services/friend/migrations/000001_create_outbox_table.up.sql
+++ b/services/friend/migrations/000001_create_outbox_table.up.sql
@@ -1,0 +1,8 @@
+CREATE TABLE IF NOT EXISTS outbox (
+    id SERIAL PRIMARY KEY,
+    event_type VARCHAR(50) NOT NULL,
+    payload JSONB NOT NULL,
+    status VARCHAR(20) DEFAULT 'pending' NOT NULL,
+    created_at TIMESTAMPTZ DEFAULT NOW(),
+    processed_at TIMESTAMPTZ
+);


### PR DESCRIPTION
## Implement Outbox Pattern in Friend Service

This PR addresses the second part of our assigned task:

1. ~~Implement graceful shutdown in all services~~ (previously completed)
2. ⭐ Implement the Outbox pattern in one of the services

We've chosen to implement the Outbox pattern in the Friend service to enhance reliability in event publishing.

### Changes

- Add `OutboxRepository` interface and implementation
- Modify `FriendUseCase` to use Outbox for event storage
- Implement `OutboxProcessor` for asynchronous event processing
- Update dependency injection setup in `wire.go`
- Extend `App` structure to manage `OutboxProcessor` lifecycle

### Key Files Changed

- `internal/core/ports/repository.go`
- `internal/repository/repository.go`
- `internal/repository/outbox_repository.go`
- `internal/usecase/friend_usecase.go`
- `internal/service/outbox_processor_service.go`
- `internal/di/wire.go`
- `internal/app/app.go`

### Testing

- Unit tests updated to reflect new Outbox functionality
- Manual testing performed to ensure correct event processing

### Notes

- Outbox table creation SQL script included in `migrations` folder
- `make migrate-up` command added to apply the new migration

### Next Steps

- Integrate with actual message broker (e.g., Kafka, RabbitMQ)
- Implement retry mechanism for failed event publications
- Add monitoring and alerting for Outbox processor

Closes #[Issue Number]